### PR TITLE
Support for alias (versioned) lambda functions

### DIFF
--- a/lambda_invoke/simple_proxy.py
+++ b/lambda_invoke/simple_proxy.py
@@ -67,7 +67,10 @@ class LambdaSimpleProxy:
 
     @property
     def function_name(self):
-        return self.url.hostname
+        host_parts = self.url.hostname.split(".")
+        if len(host_parts) > 1:
+            return f"{host_parts[-1]}:{host_parts[-2]}"
+        return host_parts[0]
 
     @property
     def request_query_string(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = lambda-invoke
-version = 0.3
+version = 0.4
 author = Ilya Sukhanov
 author_email = ilya@sukhanov.net
 license = MIT license
-description = Conviniently invoke lambda mimicking a proxy invocation 
+description = Conveniently invoke lambda mimicking a proxy invocation 
 keywords = 
 	aws
 	lambda-invoke


### PR DESCRIPTION
Calling http+lambda://v1.example/foo will now call lambda function example:v1 this enables invocation of specific lambda alias.

Calling with a top level host only http+lambda://example/ will call by name only.

If more than 2 host parts are supplied rest are ignored.