### PR TITLE
fix multiValueQueryStringParameters

### DIFF
--- a/lambda_invoke/simple_proxy.py
+++ b/lambda_invoke/simple_proxy.py
@@ -74,21 +74,14 @@ class LambdaSimpleProxy:
 
     @property
     def request_query_string(self):
-        qs = {
+        return {
             "queryStringParameters": {
-                key: value[0]
-                for key, value in parse_qs(self.url.query).items()
-                if len(value) == 1
-            }
+                key: value[0] for key, value in parse_qs(self.url.query).items()
+            },
+            "multiValueQueryStringParameters": {
+                key: value for key, value in parse_qs(self.url.query).items()
+            },
         }
-        multi_value_qs = {
-            key: value
-            for key, value in parse_qs(self.url.query).items()
-            if len(value) > 1
-        }
-        if multi_value_qs:
-            qs["multiValueQueryStringParameters"] = multi_value_qs
-        return qs
 
     @property
     def request_body(self):

--- a/tests/test_simple_proxy.py
+++ b/tests/test_simple_proxy.py
@@ -117,7 +117,10 @@ class TestSimpleProxy(PatcherBase, TestCase):
             self.mock_client.invoke.call_args.kwargs.get("Payload")
         )
         assert sent_payload.get("queryStringParameters") == {"a": "1", "b": "2"}
-        assert "multiValueQueryStringParameters" not in sent_payload.keys()
+        assert sent_payload.get("multiValueQueryStringParameters") == {
+            "a": ["1"],
+            "b": ["2"],
+        }
 
     def test_mix_multi_value_query_string(self):
         proxy = LambdaSimpleProxy(
@@ -128,9 +131,10 @@ class TestSimpleProxy(PatcherBase, TestCase):
         sent_payload = json.loads(
             self.mock_client.invoke.call_args.kwargs.get("Payload")
         )
-        assert sent_payload.get("queryStringParameters") == {"b": "2"}
+        assert sent_payload.get("queryStringParameters") == {"a": "1", "b": "2"}
         assert sent_payload.get("multiValueQueryStringParameters") == {
-            "a": ["1", "bob"]
+            "a": ["1", "bob"],
+            "b": ["2"],
         }
 
     def test_only_multi_value_query_string(self):
@@ -142,7 +146,7 @@ class TestSimpleProxy(PatcherBase, TestCase):
         sent_payload = json.loads(
             self.mock_client.invoke.call_args.kwargs.get("Payload")
         )
-        assert sent_payload.get("queryStringParameters") == {}
+        assert sent_payload.get("queryStringParameters") == {"a": "1"}
         assert sent_payload.get("multiValueQueryStringParameters") == {
             "a": ["1", "bob"]
         }


### PR DESCRIPTION
I misread the specs [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format)
Fixing it.  Also tested it locally, by running facade locally pointing to dev energie via relay endpoint.